### PR TITLE
Update Enemy.cs

### DIFF
--- a/Enemy.cs
+++ b/Enemy.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 [RequireComponent (typeof (UnityEngine.AI.NavMeshAgent))]
@@ -10,16 +9,20 @@ public class Enemy : LivingEntity
 
     UnityEngine.AI.NavMeshAgent pathfinder;
     Transform target;
+    LivingEntity targetEntity;
     Material skinMaterial;
 
     Color originalColour;
 
     float attackDistanceThreshold = 0.5f;
     float timeBetweenAttacks = 1;
+    float damage = 1;
 
     float nextAttackTime;
     float myCollisionRadius;
     float targetCollisionRadius;
+
+    bool hasTarget;
 
     protected override void Start()
     {
@@ -28,25 +31,42 @@ public class Enemy : LivingEntity
         skinMaterial = GetComponent<Renderer>().material;
         originalColour = skinMaterial.color;
 
-        currentState = State.Chasing;
-        target = GameObject.FindGameObjectWithTag("Player").transform;
+        if (GameObject.FindGameObjectWithTag("Player") != null)
+        {
+            currentState = State.Chasing;
+            hasTarget = true;
 
-        myCollisionRadius = GetComponent<CapsuleCollider>().radius;
-        targetCollisionRadius = target.GetComponent<CapsuleCollider>().radius;
+            target = GameObject.FindGameObjectWithTag("Player").transform;
+            targetEntity = target.GetComponent<LivingEntity> ();
+            targetEntity.OnDeath += OnTargetDeath;
 
-        StartCoroutine(UpdatePath());
+
+            myCollisionRadius = GetComponent<CapsuleCollider>().radius;
+            targetCollisionRadius = target.GetComponent<CapsuleCollider>().radius;
+
+            StartCoroutine(UpdatePath());
+        }
+    }
+
+    void OnTargetDeath()
+    {
+        hasTarget = false;
+        currentState = State.Idle;
     }
 
     void Update()
     {
-        if (Time.time > nextAttackTime)
+        if (hasTarget)
         {
-            float sqrDstToTarget = (target.position - transform.position).sqrMagnitude;
-
-            if (sqrDstToTarget < Mathf.Pow(attackDistanceThreshold +myCollisionRadius + targetCollisionRadius, 2))
+            if (Time.time > nextAttackTime)
             {
-                nextAttackTime = Time.time + timeBetweenAttacks;
-                StartCoroutine(Attack());
+                float sqrDstToTarget = (target.position - transform.position).sqrMagnitude;
+
+                if (sqrDstToTarget < Mathf.Pow(attackDistanceThreshold + myCollisionRadius + targetCollisionRadius, 2))
+                {
+                    nextAttackTime = Time.time + timeBetweenAttacks;
+                    StartCoroutine(Attack());
+                }
             }
         }
     }
@@ -64,9 +84,15 @@ public class Enemy : LivingEntity
         float attackSpeed = 3;
 
         skinMaterial.color = Color.blue;
+        bool hasAppliedDamage = false;
 
         while(percent <=1)
         {
+            if(percent >= .5f && !hasAppliedDamage)
+            {
+                hasAppliedDamage = true;
+                targetEntity.TakeDamage(damage);
+            }
             percent += Time.deltaTime * attackSpeed;
             float interpolation = (-Mathf.Pow(percent,2) + percent) *4;
             transform.position = Vector3.Lerp(originalPosition, attackPosition, interpolation);
@@ -83,7 +109,7 @@ public class Enemy : LivingEntity
     {
         float refreshRate = .25f;
 
-        while (target != null)
+        while (hasTarget)
         {
             if (currentState == State.Chasing)
             {
@@ -98,3 +124,4 @@ public class Enemy : LivingEntity
         }
     }
 }
+

--- a/IDamageable.cs
+++ b/IDamageable.cs
@@ -1,8 +1,9 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public interface IDamageable
 {
     void TakeHit(float damage, RaycastHit hit);
+
+    void TakeDamage (float damage);
+
 }

--- a/LivingEntity.cs
+++ b/LivingEntity.cs
@@ -17,9 +17,14 @@ public class LivingEntity : MonoBehaviour, IDamageable
 
     public void TakeHit(float damage, RaycastHit hit)
     {
+        TakeDamage(damage);
+    }
+
+    public void TakeDamage (float damage)
+    {
         health -= damage;
 
-        if(health <= 0 && !dead)
+        if (health <= 0 && !dead)
         {
             Die();
         }

--- a/Projectile.cs
+++ b/Projectile.cs
@@ -8,6 +8,20 @@ public class Projectile : MonoBehaviour
     float speed = 10;
     float damage = 1;
 
+    float lifetime = 3;
+    float skinWidth = .1f;
+
+    void Start()
+    {
+        Destroy(gameObject, lifetime);
+
+        Collider[] initialCollisions = Physics.OverlapSphere(transform.position, .1f, collisionMask);
+        if(initialCollisions.Length > 0)
+        {
+            OnHitObject(initialCollisions[0]);
+        }
+    }
+
     public void SetSpeed(float newSpeed)
     {
         speed = newSpeed;
@@ -25,7 +39,7 @@ public class Projectile : MonoBehaviour
         Ray ray = new Ray(transform.position, transform.forward);
         RaycastHit hit;
 
-        if (Physics.Raycast(ray, out hit, moveDistance, collisionMask, QueryTriggerInteraction.Collide))
+        if (Physics.Raycast(ray, out hit, moveDistance + skinWidth, collisionMask, QueryTriggerInteraction.Collide))
         {
             OnHitObject(hit);
         }
@@ -40,4 +54,15 @@ public class Projectile : MonoBehaviour
         }
         GameObject.Destroy(gameObject);
     }
+
+    void OnHitObject(Collider c)
+    {
+        IDamageable damageableObject = c.GetComponent<IDamageable>();
+        if (damageableObject != null)
+        {
+            damageableObject.TakeDamage(damage);
+        }
+        GameObject.Destroy(gameObject);
+    }
 }
+


### PR DESCRIPTION
Episode #7 (Loose ends)
1. Enabled enemy entity to know when target (player) is dead, so it doesn't have to update its path 'ontargetdeath'.
2. Fixed bug where bullet goes through enemy when they overlap at the point the bullet is spawned.